### PR TITLE
feat: add release workflow with smart major tag updates

### DIFF
--- a/.github/scripts/changelog.sh
+++ b/.github/scripts/changelog.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Shared functions for CHANGELOG parsing in release workflows
+#
+# Usage:
+#   source .github/scripts/changelog.sh
+#   detect_new_version "current_changelog.md" "base_changelog.md"
+#   extract_release_notes "changelog.md" "1.0.0"
+
+set -euo pipefail
+
+# Extract version numbers from a CHANGELOG.md file
+# Format expected: ## [1.0.0] - 2024-01-15
+# Args: $1 = path to changelog file
+# Output: space-separated list of versions (e.g., "1.0.0 0.9.0 0.8.0")
+get_versions() {
+  local file="$1"
+  if [[ ! -f "$file" ]]; then
+    echo ""
+    return
+  fi
+  grep -E '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' "$file" |
+    sed -E 's/^## \[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/' || true
+}
+
+# Detect a new version by comparing two changelogs
+# Args: $1 = current changelog, $2 = base changelog
+# Output: Sets NEW_VERSION variable, or empty if no new version
+detect_new_version() {
+  local current_file="$1"
+  local base_file="$2"
+
+  local current_versions
+  local base_versions
+  current_versions=$(get_versions "$current_file")
+  base_versions=$(get_versions "$base_file")
+
+  NEW_VERSION=""
+  for version in $current_versions; do
+    if ! echo "$base_versions" | grep -qw "$version"; then
+      NEW_VERSION="$version"
+      break
+    fi
+  done
+
+  echo "$NEW_VERSION"
+}
+
+# Extract release notes for a specific version from CHANGELOG.md
+# Args: $1 = changelog file, $2 = version (e.g., "1.0.0")
+# Output: The release notes content
+extract_release_notes() {
+  local file="$1"
+  local version="$2"
+
+  awk -v ver="$version" '
+$0 ~ "^## \\[" ver "\\]" { capture=1; next }
+/^## \[/ { capture=0 }
+capture { print }
+' "$file"
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,256 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - "v*.*.*"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+jobs:
+  # Comment on PRs that add a new version to CHANGELOG.md
+  detect-release:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+
+      - name: Checkout base branch for comparison
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Detect new version in CHANGELOG
+        id: detect
+        run: |
+          source .github/scripts/changelog.sh
+
+          NEW_VERSION=$(detect_new_version "CHANGELOG.md" "base/CHANGELOG.md")
+
+          if [[ -n "$NEW_VERSION" ]]; then
+            echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+            echo "has_release=true" >> "$GITHUB_OUTPUT"
+            echo "Detected new version: $NEW_VERSION"
+
+            NOTES=$(extract_release_notes "CHANGELOG.md" "$NEW_VERSION")
+            echo "$NOTES" > /tmp/release_notes.md
+          else
+            echo "has_release=false" >> "$GITHUB_OUTPUT"
+            echo "No new version detected"
+          fi
+
+      - name: Find existing comment
+        if: steps.detect.outputs.has_release == 'true'
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: "<!-- release-preview -->"
+
+      - name: Build comment body
+        if: steps.detect.outputs.has_release == 'true'
+        id: comment-body
+        run: |
+          VERSION="${{ steps.detect.outputs.new_version }}"
+          MAJOR_VERSION="${VERSION%%.*}"
+          NOTES=$(cat /tmp/release_notes.md)
+
+          {
+            echo "body<<EOF"
+            echo "<!-- release-preview -->"
+            echo "## Release Preview"
+            echo ""
+            echo "This PR will create **v${VERSION}** when merged."
+            echo ""
+            echo "### What will happen"
+            echo "- Tag \`v${VERSION}\` will be created"
+            echo "- A GitHub Release will be published"
+            echo "- The major version tag \`v${MAJOR_VERSION}\` will be updated"
+            echo ""
+            echo "### Release Notes Preview"
+            echo ""
+            if [[ -n "$NOTES" ]]; then
+              echo "$NOTES"
+            else
+              echo "_No release notes found for this version._"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create or update comment
+        if: steps.detect.outputs.has_release == 'true'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: ${{ steps.comment-body.outputs.body }}
+          edit-mode: replace
+
+  # Create a release when a commit with a new CHANGELOG version is pushed to main
+  create-release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect new version in CHANGELOG
+        id: detect
+        run: |
+          source .github/scripts/changelog.sh
+
+          # Get CHANGELOG from parent commit for comparison
+          git show HEAD^:CHANGELOG.md > /tmp/changelog_parent.md 2>/dev/null || true
+
+          NEW_VERSION=$(detect_new_version "CHANGELOG.md" "/tmp/changelog_parent.md")
+
+          if [[ -n "$NEW_VERSION" ]]; then
+            {
+              echo "new_version=$NEW_VERSION"
+              echo "new_tag=v$NEW_VERSION"
+              echo "has_release=true"
+            } >> "$GITHUB_OUTPUT"
+            echo "Detected new version: $NEW_VERSION"
+          else
+            echo "has_release=false" >> "$GITHUB_OUTPUT"
+            echo "No new version detected, skipping release"
+          fi
+
+      - name: Extract release notes from CHANGELOG
+        if: steps.detect.outputs.has_release == 'true'
+        run: |
+          source .github/scripts/changelog.sh
+
+          VERSION="${{ steps.detect.outputs.new_version }}"
+          NOTES=$(extract_release_notes "CHANGELOG.md" "$VERSION")
+
+          # Remove empty lines and provide default if empty
+          NOTES=$(echo "$NOTES" | sed '/^[[:space:]]*$/d')
+          if [[ -z "$NOTES" ]]; then
+            NOTES="Release v${VERSION}"
+          fi
+
+          echo "$NOTES" > /tmp/release_notes.md
+          echo "Release notes:"
+          cat /tmp/release_notes.md
+
+      - name: Create and push tag
+        if: steps.detect.outputs.has_release == 'true'
+        run: |
+          TAG="${{ steps.detect.outputs.new_tag }}"
+
+          # Check if tag already exists
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git tag "$TAG"
+          git push origin "$TAG"
+
+      - name: Create GitHub Release
+        if: steps.detect.outputs.has_release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.detect.outputs.new_tag }}"
+
+          # Check if release already exists
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping"
+            exit 0
+          fi
+
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file /tmp/release_notes.md
+
+  # Update major version tag when a semver tag is pushed
+  update-major-tag:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update major version tag
+        run: |
+          set -euo pipefail
+
+          # Extract version from the pushed tag (e.g., v1.2.3 -> 1.2.3)
+          PUSHED_TAG="${GITHUB_REF#refs/tags/}"
+          PUSHED_VERSION="${PUSHED_TAG#v}"
+
+          # Extract major version (e.g., 1.2.3 -> v1)
+          MAJOR_TAG="v${PUSHED_VERSION%%.*}"
+
+          echo "Pushed tag: $PUSHED_TAG"
+          echo "Major tag: $MAJOR_TAG"
+
+          # Function to compare semantic versions
+          # Returns 0 if $1 > $2, 1 otherwise
+          version_gt() {
+            local v1_major v1_minor v1_patch v2_major v2_minor v2_patch
+            IFS='.' read -r v1_major v1_minor v1_patch <<< "$1"
+            IFS='.' read -r v2_major v2_minor v2_patch <<< "$2"
+
+            # Default to 0 if empty
+            v1_minor=${v1_minor:-0}
+            v1_patch=${v1_patch:-0}
+            v2_minor=${v2_minor:-0}
+            v2_patch=${v2_patch:-0}
+
+            if (( v1_major > v2_major )); then return 0; fi
+            if (( v1_major < v2_major )); then return 1; fi
+            if (( v1_minor > v2_minor )); then return 0; fi
+            if (( v1_minor < v2_minor )); then return 1; fi
+            if (( v1_patch > v2_patch )); then return 0; fi
+            return 1
+          }
+
+          # Check if major tag exists
+          if git rev-parse "$MAJOR_TAG" >/dev/null 2>&1; then
+            # Get the version that the major tag currently points to
+            CURRENT_TAG=$(git describe --tags --exact-match "$MAJOR_TAG" 2>/dev/null || echo "")
+
+            if [[ -z "$CURRENT_TAG" ]] || [[ "$CURRENT_TAG" = "$MAJOR_TAG" ]]; then
+              # Major tag points directly to a commit, find the highest matching tag
+              CURRENT_VERSION=$(git tag -l "v${PUSHED_VERSION%%.*}.*.*" | sed 's/^v//' | sort -V | tail -1)
+            else
+              CURRENT_VERSION="${CURRENT_TAG#v}"
+            fi
+
+            echo "Current highest version for $MAJOR_TAG: $CURRENT_VERSION"
+
+            if version_gt "$PUSHED_VERSION" "$CURRENT_VERSION"; then
+              echo "Pushed version $PUSHED_VERSION is greater than $CURRENT_VERSION"
+              echo "Updating $MAJOR_TAG to point to $PUSHED_TAG"
+              git tag -f "$MAJOR_TAG" "$PUSHED_TAG"
+              git push origin "$MAJOR_TAG" --force
+            else
+              echo "Pushed version $PUSHED_VERSION is not greater than $CURRENT_VERSION"
+              echo "Skipping major tag update"
+            fi
+          else
+            echo "Major tag $MAJOR_TAG does not exist, creating it"
+            git tag "$MAJOR_TAG" "$PUSHED_TAG"
+            git push origin "$MAJOR_TAG"
+          fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,143 @@
+# Releasing
+
+This document describes the release process for nix-s3-cache.
+
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/):
+
+- **MAJOR** (`v1.0.0` -> `v2.0.0`): Breaking changes to the action interface
+- **MINOR** (`v1.0.0` -> `v1.1.0`): New features, backward compatible
+- **PATCH** (`v1.0.0` -> `v1.0.1`): Bug fixes, backward compatible
+
+Users reference this action via a major version tag (e.g., `@v1`), which always
+points to the latest release within that major version.
+
+## Creating a Release
+
+Releases are driven by CHANGELOG.md - the single source of truth for versions.
+
+### Steps
+
+1. **Create a PR** that updates CHANGELOG.md:
+   - Move entries from `[Unreleased]` to a new version section
+   - Use the format: `## [1.0.0] - 2024-01-15`
+   - Keep the `[Unreleased]` section (empty) for future changes
+
+2. **The workflow automatically comments** on your PR:
+   - Detects the new version in CHANGELOG.md
+   - Shows what will happen when the PR is merged
+
+3. **Merge the PR** - The workflow automatically:
+   - Creates and pushes the version tag (e.g., `v1.0.0`)
+   - Creates a GitHub Release with notes from CHANGELOG.md
+   - Updates the major version tag (e.g., `v1`)
+
+### Example CHANGELOG Update
+
+Before (in your PR):
+
+```markdown
+## [Unreleased]
+
+### Added
+- New feature X
+
+### Fixed
+- Bug Y
+```
+
+After (in your PR):
+
+```markdown
+## [Unreleased]
+
+## [1.1.0] - 2024-12-07
+
+### Added
+- New feature X
+
+### Fixed
+- Bug Y
+```
+
+## How the Release Workflow Works
+
+### On PR Open/Update
+
+1. Compares CHANGELOG.md in the PR against the base branch
+2. Detects any new version entries (e.g., `## [1.0.0] - 2024-01-15`)
+3. Comments on the PR explaining what will happen on merge
+
+### On Push to Main
+
+When a commit lands on `main` (via merge, squash, or rebase):
+
+1. Compares CHANGELOG.md against the parent commit
+2. Detects any new version entries
+3. Extracts release notes for that version
+4. Creates the version tag on the correct commit
+5. Creates a GitHub Release with the extracted notes
+
+This approach ensures the tag is always on the actual commit that landed on
+`main`, regardless of merge strategy (merge commit, squash, or rebase).
+
+### On Tag Push
+
+1. Extracts the major version (`v1.2.3` -> `v1`)
+2. Compares against the current highest version for that major
+3. Only updates `v1` if `1.2.3` is greater (prevents accidental downgrades)
+4. Creates the major tag if it doesn't exist yet
+
+This means you can safely:
+
+- Push hotfix tags for older versions (e.g., `v1.0.1` after `v1.1.0` exists)
+- Re-tag commits if needed
+- Push tags in any order
+
+## Release Checklist
+
+Before merging a release PR:
+
+- [ ] **Update CHANGELOG.md**
+  - Create a new version section with date (e.g., `## [1.0.0] - 2024-01-15`)
+  - Move all entries from `[Unreleased]` to the new section
+  - Keep the `[Unreleased]` section for future changes
+
+- [ ] **Verify CI passes**
+  - All tests pass on the PR
+  - Linting checks pass
+
+- [ ] **Review the release bot comment**
+  - Confirm the detected version is correct
+
+- [ ] **Test the action manually** (for significant changes)
+  - Test with at least one S3 provider
+
+## Manual Releases
+
+For hotfixes or special cases, you can still create releases manually:
+
+```bash
+git checkout main
+git pull origin main
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+The workflow will automatically update the major version tag.
+
+To create a GitHub Release manually:
+
+```bash
+gh release create v1.2.3 --title "v1.2.3" --notes "Release notes here"
+```
+
+## Breaking Changes (Major Version Bump)
+
+When making breaking changes:
+
+1. Document the migration path in CHANGELOG.md
+2. Consider maintaining the old major version for critical fixes
+3. Update README.md examples to use the new major version
+4. Announce the breaking change in the GitHub Release notes


### PR DESCRIPTION
## Summary

- Add CHANGELOG-driven release workflow (no labels required)
- Automatically detect, tag, and release new versions based on CHANGELOG.md changes

## How It Works

### PR Preview

When you open a PR that adds a new version to CHANGELOG.md (e.g., `## [1.0.0] - 2024-12-07`), the workflow:

1. Detects the new version by comparing against the base branch
2. Comments on the PR with a preview of the release notes
3. Updates the comment whenever the PR is updated

### Release on Push to Main

When the PR is merged (regardless of merge strategy - merge, squash, or rebase):

1. Compares CHANGELOG.md against the parent commit
2. Detects the new version entry
3. Creates the tag on the **actual commit that landed on main**
4. Creates a GitHub Release with notes extracted from CHANGELOG.md
5. Updates the major version tag (e.g., `v1`)

### Why Push to Main Instead of PR Close?

Triggering on push to `main` instead of PR merge ensures the tag is always on the correct commit:

| Merge Strategy | PR Close Event | Push to Main |
|---------------|----------------|--------------|
| Merge commit | Tags merge commit | Tags merge commit |
| Squash merge | May tag wrong commit | Tags squash commit |
| Rebase merge | May tag wrong commit | Tags rebased commit |

### Smart Major Tag Updates

| Scenario | Current `v1` | You push | Result |
|----------|--------------|----------|--------|
| Normal release | `v1.1.0` | `v1.2.0` | `v1` updated |
| Hotfix for old version | `v1.2.0` | `v1.1.1` | `v1` unchanged |