### PR TITLE
fix: update major version tag in create-release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Detect new version in CHANGELOG
         id: detect
@@ -179,7 +179,64 @@ jobs:
             --title "$TAG" \
             --notes-file /tmp/release_notes.md
 
-  # Update major version tag when a semver tag is pushed
+      - name: Update major version tag
+        if: steps.detect.outputs.has_release == 'true'
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ steps.detect.outputs.new_version }}"
+          TAG="${{ steps.detect.outputs.new_tag }}"
+          MAJOR_TAG="v${VERSION%%.*}"
+
+          echo "Version tag: $TAG"
+          echo "Major tag: $MAJOR_TAG"
+
+          # Function to compare semantic versions
+          # Returns 0 if $1 > $2, 1 otherwise
+          version_gt() {
+            local v1_major v1_minor v1_patch v2_major v2_minor v2_patch
+            IFS='.' read -r v1_major v1_minor v1_patch <<< "$1"
+            IFS='.' read -r v2_major v2_minor v2_patch <<< "$2"
+
+            # Default to 0 if empty
+            v1_minor=${v1_minor:-0}
+            v1_patch=${v1_patch:-0}
+            v2_minor=${v2_minor:-0}
+            v2_patch=${v2_patch:-0}
+
+            if (( v1_major > v2_major )); then return 0; fi
+            if (( v1_major < v2_major )); then return 1; fi
+            if (( v1_minor > v2_minor )); then return 0; fi
+            if (( v1_minor < v2_minor )); then return 1; fi
+            if (( v1_patch > v2_patch )); then return 0; fi
+            return 1
+          }
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Check if major tag exists
+          if git rev-parse "$MAJOR_TAG" >/dev/null 2>&1; then
+            # Find the highest matching tag for this major version
+            CURRENT_VERSION=$(git tag -l "v${VERSION%%.*}.*.*" | sed 's/^v//' | sort -V | tail -1)
+
+            echo "Current highest version for $MAJOR_TAG: $CURRENT_VERSION"
+
+            if version_gt "$VERSION" "$CURRENT_VERSION" || [[ "$VERSION" == "$CURRENT_VERSION" ]]; then
+              echo "Updating $MAJOR_TAG to point to $TAG"
+              git tag -f "$MAJOR_TAG" "$TAG"
+              git push origin "$MAJOR_TAG" --force
+            else
+              echo "Version $VERSION is not greater than $CURRENT_VERSION"
+              echo "Skipping major tag update"
+            fi
+          else
+            echo "Major tag $MAJOR_TAG does not exist, creating it"
+            git tag "$MAJOR_TAG" "$TAG"
+            git push origin "$MAJOR_TAG"
+          fi
+
+  # Update major version tag when a semver tag is pushed manually
   update-major-tag:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
- Fix major version tag (`v1`) not being updated after automated releases
- Root cause: Tag pushes from within a workflow using `GITHUB_TOKEN` don't trigger new workflow runs due to GitHub's recursive workflow protection
- Solution: Move the major tag update logic directly into the `create-release` job

The `update-major-tag` job is kept for manual tag pushes.