### PR TITLE
docs: release v1.0.2

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,6 @@
 {
   "MD013": false,
+  "MD024": false,
   "MD034": false,
   "MD041": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ When creating a new release:
 
 ## [Unreleased]
 
+## [1.0.2] - 2025-12-08
+
+### Fixed
+
+- Fix major version tag not being updated after automated releases ([#17](https://github.com/lemmih/nix-s3-cache-action/pull/17))
+
 ## [1.0.1] - 2025-12-07
 
 ### Fixed
@@ -62,6 +68,7 @@ Initial release of nix-s3-cache.
 - AWS OIDC authentication support
 - Optional automatic bucket creation
 
-[Unreleased]: https://github.com/lemmih/nix-s3-cache-action/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/lemmih/nix-s3-cache-action/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/lemmih/nix-s3-cache-action/releases/tag/v1.0.2
 [1.0.1]: https://github.com/lemmih/nix-s3-cache-action/releases/tag/v1.0.1
 [1.0.0]: https://github.com/lemmih/nix-s3-cache-action/releases/tag/v1.0.0


### PR DESCRIPTION
## Summary
- Release v1.0.2 with the fix for major version tag updates after automated releases