### PR TITLE
feat: support runners without systemd (Docker, custom runners)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -7,6 +7,88 @@ if ! command -v nix >/dev/null 2>&1; then
   exit 1
 fi
 
+# Check if nix-daemon is running (multi-user mode) or not (single-user/root-only mode)
+is_daemon_running() {
+  pgrep -x "nix-daemon" >/dev/null 2>&1
+}
+
+# Wait for nix-daemon socket to appear
+wait_for_nix_socket() {
+  local socket_path="/nix/var/nix/daemon-socket/socket"
+  local max_attempts=120  # 2 minutes at 1 second intervals
+  local attempt=0
+
+  while [ $attempt -lt $max_attempts ]; do
+    if [ -S "$socket_path" ]; then
+      return 0
+    fi
+    sleep 1
+    attempt=$((attempt + 1))
+  done
+
+  echo "Timed out waiting for nix-daemon socket"
+  return 1
+}
+
+# Start nix-daemon directly as a background process (for environments without systemd)
+start_daemon_directly() {
+  local daemon_bin="/nix/var/nix/profiles/default/bin/nix-daemon"
+
+  if [ ! -x "$daemon_bin" ]; then
+    echo "nix-daemon binary not found at $daemon_bin"
+    return 1
+  fi
+
+  echo "Starting nix-daemon directly..."
+
+  # Kill any existing daemon first
+  sudo pkill -TERM -x "nix-daemon" 2>/dev/null || true
+  sleep 1
+
+  # Start the daemon as a detached background process
+  # Using nohup to ensure it survives after this script exits
+  sudo nohup "$daemon_bin" >/dev/null 2>&1 &
+
+  # Wait for the socket to appear
+  if wait_for_nix_socket; then
+    echo "nix-daemon started successfully"
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Function to restart nix-daemon using available init system
+restart_nix_daemon() {
+  # Try systemctl (Linux with systemd)
+  if command -v systemctl >/dev/null 2>&1; then
+    if sudo systemctl restart nix-daemon 2>/dev/null; then
+      echo "Restarted nix-daemon via systemctl"
+      return 0
+    fi
+  fi
+
+  # Try launchctl (macOS)
+  if command -v launchctl >/dev/null 2>&1; then
+    # Try common launchd service names
+    for service in "systems.determinate.nix-daemon" "org.nixos.nix-daemon"; do
+      if sudo launchctl kickstart -k "system/${service}" 2>/dev/null; then
+        echo "Restarted nix-daemon via launchctl (${service})"
+        return 0
+      fi
+    done
+  fi
+
+  # No init system available - start daemon directly
+  # This is common in Docker containers and similar environments
+  if start_daemon_directly; then
+    return 0
+  fi
+
+  # No restart method worked
+  return 1
+}
+
 # Determine config file
 if [ -f /etc/nix/nix.custom.conf ]; then
   CONFIG_FILE="/etc/nix/nix.custom.conf"
@@ -96,11 +178,54 @@ fi
 sudo chmod +x /etc/nix/post-build-hook.sh
 
 # Configure Nix
-sudo tee -a "$CONFIG_FILE" >/dev/null <<EOF
-extra-substituters = s3://${INPUT_BUCKET}?${NIX_S3_PARAMS}
+# Build the configuration lines
+NIX_EXTRA_CONFIG="extra-substituters = s3://${INPUT_BUCKET}?${NIX_S3_PARAMS}
 extra-trusted-public-keys = ${INPUT_PUBLIC_KEY}
-post-build-hook = /etc/nix/post-build-hook.sh
-EOF
+post-build-hook = /etc/nix/post-build-hook.sh"
 
-# Restart nix-daemon
-sudo systemctl restart nix-daemon || true
+# Write config to file
+echo "$NIX_EXTRA_CONFIG" | sudo tee -a "$CONFIG_FILE" >/dev/null
+
+# Check if we're running in single-user mode (no daemon) or multi-user mode (with daemon)
+if is_daemon_running; then
+  # Multi-user mode: need to restart daemon to pick up new config
+  if restart_nix_daemon; then
+    echo "Nix daemon restarted successfully. Configuration is active."
+  else
+    # Daemon restart failed - fall back to NIX_CONFIG for substituter settings
+    echo "Warning: Could not restart nix-daemon."
+    echo "         Configuring substituter via NIX_CONFIG environment variable."
+
+    # Export NIX_CONFIG to GITHUB_ENV so subsequent steps pick up the substituter
+    # NIX_CONFIG takes precedence and doesn't require daemon restart for client-side settings
+    NIX_CONFIG_VALUE="extra-substituters = s3://${INPUT_BUCKET}?${NIX_S3_PARAMS}
+extra-trusted-public-keys = ${INPUT_PUBLIC_KEY}"
+
+    # Append to existing NIX_CONFIG if set
+    if [ -n "${NIX_CONFIG:-}" ]; then
+      NIX_CONFIG_VALUE="${NIX_CONFIG}
+${NIX_CONFIG_VALUE}"
+    fi
+
+    # Export to current shell
+    export NIX_CONFIG="$NIX_CONFIG_VALUE"
+
+    # Export to GITHUB_ENV for subsequent steps (if running in GitHub Actions)
+    if [ -n "${GITHUB_ENV:-}" ]; then
+      # Use heredoc delimiter for multi-line value
+      {
+        echo "NIX_CONFIG<<EOF_NIX_CONFIG"
+        echo "$NIX_CONFIG_VALUE"
+        echo "EOF_NIX_CONFIG"
+      } >> "$GITHUB_ENV"
+    fi
+
+    echo "Note: post-build-hook requires nix-daemon restart to take effect."
+    echo "      Cache downloads will work, but automatic uploads after builds may not."
+  fi
+else
+  # Single-user mode (no daemon) - common in Docker containers
+  # In this mode, Nix reads config directly from nix.conf without needing a daemon restart
+  echo "Detected single-user Nix installation (no daemon)."
+  echo "Configuration written to ${CONFIG_FILE}. All settings are active."
+fi


### PR DESCRIPTION
## Summary

- Add support for custom GitHub runners that don't have `systemctl` available (e.g., Docker-based runners like `python:3.11-slim-bookworm`)
- Implement multiple daemon restart strategies with automatic fallback

## Changes

### New daemon restart methods (tried in order):

1. **`systemctl restart nix-daemon`** - Linux with systemd (standard GitHub runners)
2. **`launchctl kickstart -k`** - macOS with launchd
3. **Direct daemon spawn** - Start `nix-daemon` as a detached background process using `nohup`

### Single-user mode detection

When no `nix-daemon` is running (common when Nix is installed with `--init none` in containers), the script detects this and skips the restart entirely since config changes take effect immediately.

### Fallback to NIX_CONFIG

If all restart methods fail, substituter settings are exported via the `NIX_CONFIG` environment variable to `GITHUB_ENV`, ensuring cache downloads still work.

## Environments Supported

| Environment | Daemon? | Restart Method |
|-------------|---------|----------------|
| Standard GitHub runner (Ubuntu) | Yes | `systemctl` |
| macOS runner | Yes | `launchctl` |
| Docker container with daemon | Yes | `nohup nix-daemon &` |
| Docker container without daemon | No | Not needed |

## Implementation Reference

The direct daemon spawn approach is based on how [DeterminateSystems/nix-installer-action](https://github.com/DeterminateSystems/nix-installer-action) handles non-systemd environments in its `spawnDetached()` function.