### PR TITLE
docs: release v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ When creating a new release:
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-06-13
+
+No user-facing changes.
+
 ## [1.0.2] - 2025-12-08
 
 ### Fixed
@@ -68,7 +72,8 @@ Initial release of nix-s3-cache.
 - AWS OIDC authentication support
 - Optional automatic bucket creation
 
-[Unreleased]: https://github.com/lemmih/nix-s3-cache-action/compare/v1.0.2...HEAD
+[Unreleased]: https://github.com/lemmih/nix-s3-cache-action/compare/v1.0.3...HEAD
+[1.0.3]: https://github.com/lemmih/nix-s3-cache-action/releases/tag/v1.0.3
 [1.0.2]: https://github.com/lemmih/nix-s3-cache-action/releases/tag/v1.0.2
 [1.0.1]: https://github.com/lemmih/nix-s3-cache-action/releases/tag/v1.0.1
 [1.0.0]: https://github.com/lemmih/nix-s3-cache-action/releases/tag/v1.0.0


### PR DESCRIPTION
## Summary
- Prepare changelog release section for v1.0.3 dated 2026-06-13
- Update changelog comparison links for the next unreleased cycle

## Verification
- Release parser detects 1.0.3 and extracts the expected notes
- nix flake check